### PR TITLE
#21 add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:alpine
+
+RUN apk apk update && apk upgrade && apk add --no-cache git
+
+RUN mkdir /muffet
+ADD . /muffet/
+WORKDIR /muffet
+
+RUN go get -d .
+RUN go build -o main .
+
+ENTRYPOINT ["/muffet/main"]


### PR DESCRIPTION
Usage
```
$ docker build -t muffet .
$ docker run muffet -v https://coel-lang.org
```

This image can be pushed to Docker Hub by the maintainers.