### PR TITLE
Add snapcraft support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,26 @@
+name: muffet
+version: "latest"
+version-script: git -C parts/muffet/build rev-parse --short HEAD
+summary:  Fast website link checker in Go
+description: |
+  Muffet is a website link checker which scrapes and inspects all pages in a
+  website recursively.
+
+grade: stable
+confinement: strict
+
+apps:
+  muffet:
+    command: bin/muffet
+    plugs:
+      - network
+
+parts:
+  go:
+    source-tag: go1.10.1
+  muffet:
+    plugin: go
+    after: [go]
+    source: https://github.com/raviqqe/muffet.git
+    source-type: git
+    go-importpath: github.com/raviqqe/muffet


### PR DESCRIPTION
Hello! Thanks for making muffet, it's great!

This PR adds snapcraft.yaml to enable building snaps of muffet. This enables you to distribute muffet as a snap (you can find out more about snaps from https://snapcraft.io/). Snaps are supported on Ubuntu, Debian, Fedora, OpenSUSE, Arch and numerous other distros. 

I've already uploaded a build of muffet (for x86/x86_64/armhf/arm64) to the snap store. So users today can:-

  snap install muffet

If you accept this PR, once landed there's a few steps to hand this over to you from me in the store.

* You should sign up for a snap store account at https://dashboard.snapcraft.io/
* On the forum, start a thread to request the transfer of ownership of muffet from me (snapcrafters) to you
* Once transferred, go to our build service https://build.snapcraft.io/ and login using github. Add your muffet repo, give it the registered snap name 'muffet' and it will start building

That will get builds on each commit pushed to the edge channel in the store.

As you haven't done any stable releases yet, I've just been doing basic shakedown test of the build in edge and then promoting it to the stable channel periodically. This is done via the dashboard at https://dashboard.snapcraft.io/snaps/muffet/revisions/

Alternatively on your mac you can `brew install snapcraft` and `snapcraft login` to the store and then `snapcraft release muffet <revno> <channelname>` to release directly from your terminal.

If you have any questions, I'm happy to answer them here, or use the forum linked above.