### PR TITLE
Add an -i flag for ignoring the fragment part of URLs

### DIFF
--- a/arguments.go
+++ b/arguments.go
@@ -10,17 +10,19 @@ import (
 const usage = `Muffet, the web repairgirl
 
 Usage:
-	muffet [-c <concurrency>] [-v] <url>
+	muffet [-c <concurrency>] [-f] [-v] <url>
 
 Options:
 	-c, --concurrency <concurrency>  Roughly maximum number of concurrent HTTP connections. [default: 512]
-	-h, --help  Show this help.
-	-v, --verbose  Show successful results too.`
+	-f, --ignore-fragments           Ignore URL fragments.
+	-h, --help                       Show this help.
+	-v, --verbose                    Show successful results too.`
 
 type arguments struct {
-	concurrency int
-	url         string
-	verbose     bool
+	concurrency     int
+	url             string
+	verbose         bool
+	ignoreFragments bool
 }
 
 func getArguments(ss []string) (arguments, error) {
@@ -40,5 +42,5 @@ func getArguments(ss []string) (arguments, error) {
 		return arguments{}, err
 	}
 
-	return arguments{int(c), args["<url>"].(string), args["--verbose"].(bool)}, nil
+	return arguments{int(c), args["<url>"].(string), args["--verbose"].(bool), args["--ignore-fragments"].(bool)}, nil
 }

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -12,6 +12,8 @@ func TestGetArguments(t *testing.T) {
 		{"-c", "foo", "https://foo.com"},
 		{"-v", "https://foo.com"},
 		{"--verbose", "https://foo.com"},
+		{"-v", "-f", "https://foo.com"},
+		{"-v", "--ignore-fragments", "https://foo.com"},
 	} {
 		getArguments(ss)
 	}

--- a/checker.go
+++ b/checker.go
@@ -35,8 +35,8 @@ type checker struct {
 	donePages concurrentStringSet
 }
 
-func newChecker(s string, c int) (checker, error) {
-	f := newFetcher(c)
+func newChecker(s string, c int, i bool) (checker, error) {
+	f := newFetcher(c, i)
 	p, err := f.Fetch(s)
 
 	if err != nil {

--- a/checker_test.go
+++ b/checker_test.go
@@ -7,18 +7,18 @@ import (
 )
 
 func TestNewChecker(t *testing.T) {
-	_, err := newChecker(rootURL, 1)
+	_, err := newChecker(rootURL, 1, false)
 	assert.Nil(t, err)
 }
 
 func TestNewCheckerError(t *testing.T) {
-	_, err := newChecker(":", 1)
+	_, err := newChecker(":", 1, false)
 	assert.NotNil(t, err)
 }
 
 func TestCheckerCheck(t *testing.T) {
 	for _, s := range []string{rootURL, fragmentURL} {
-		c, _ := newChecker(s, 1)
+		c, _ := newChecker(s, 1, false)
 
 		go c.Check()
 
@@ -29,7 +29,7 @@ func TestCheckerCheck(t *testing.T) {
 }
 
 func TestCheckerCheckWithTags(t *testing.T) {
-	c, _ := newChecker(tagsURL, 1)
+	c, _ := newChecker(tagsURL, 1, false)
 
 	go c.Check()
 
@@ -40,7 +40,7 @@ func TestCheckerCheckWithTags(t *testing.T) {
 }
 
 func TestCheckerCheckPage(t *testing.T) {
-	c, _ := newChecker(rootURL, 256)
+	c, _ := newChecker(rootURL, 256, false)
 
 	p, err := c.fetcher.Fetch(existentURL)
 	assert.Nil(t, err)
@@ -51,7 +51,7 @@ func TestCheckerCheckPage(t *testing.T) {
 }
 
 func TestCheckerCheckPageError(t *testing.T) {
-	c, _ := newChecker(rootURL, 256)
+	c, _ := newChecker(rootURL, 256, false)
 
 	p, err := c.fetcher.Fetch(erroneousURL)
 	assert.Nil(t, err)

--- a/fetcher.go
+++ b/fetcher.go
@@ -15,13 +15,15 @@ type fetcher struct {
 	client              *fasthttp.Client
 	connectionSemaphore semaphore
 	cache               *sync.Map
+	ignoreFragments     bool
 }
 
-func newFetcher(c int) fetcher {
+func newFetcher(c int, i bool) fetcher {
 	return fetcher{
 		&fasthttp.Client{MaxConnsPerHost: c},
 		newSemaphore(c),
 		&sync.Map{},
+		i,
 	}
 }
 
@@ -69,7 +71,7 @@ func (f fetcher) fetchHTML(u, id string) (*html.Node, error) {
 		return nil, err
 	}
 
-	if id != "" {
+	if !f.ignoreFragments && id != "" {
 		if _, ok := scrape.Find(n, func(n *html.Node) bool {
 			return scrape.Attr(n, "id") == id
 		}); !ok {

--- a/fetcher_test.go
+++ b/fetcher_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func TestNewFetcher(t *testing.T) {
-	newFetcher(1)
+	newFetcher(1, false)
 }
 
 func TestFetcherCache(t *testing.T) {
-	f := newFetcher(1)
+	f := newFetcher(1, false)
 
 	p, err := f.Fetch(rootURL)
 
@@ -35,8 +35,20 @@ func TestFetcherCache(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestFetcherFetchIgnoreFragments(t *testing.T) {
+	p, err := newFetcher(1, false).Fetch(nonExistentIDURL)
+
+	assert.Equal(t, (*page)(nil), p)
+	assert.NotNil(t, err)
+
+	p, err = newFetcher(1, true).Fetch(nonExistentIDURL)
+
+	assert.NotEqual(t, (*page)(nil), p)
+	assert.Nil(t, err)
+}
+
 func TestFetcherFetchError(t *testing.T) {
-	f := newFetcher(1)
+	f := newFetcher(1, false)
 
 	for _, s := range []string{nonExistentURL, ":"} {
 		p, err := f.Fetch(s)
@@ -47,7 +59,7 @@ func TestFetcherFetchError(t *testing.T) {
 }
 
 func TestFetcherFetchHTML(t *testing.T) {
-	f := newFetcher(1)
+	f := newFetcher(1, false)
 
 	for _, s := range []string{rootURL, existentURL, fragmentURL, erroneousURL} {
 		n, err := f.fetchHTML(s, "")
@@ -58,7 +70,7 @@ func TestFetcherFetchHTML(t *testing.T) {
 }
 
 func TestFetcherFetchHTMLWithFragment(t *testing.T) {
-	f := newFetcher(1)
+	f := newFetcher(1, false)
 
 	n, err := f.fetchHTML(fragmentURL, "foo")
 	assert.NotEqual(t, (*html.Node)(nil), n)
@@ -70,7 +82,7 @@ func TestFetcherFetchHTMLWithFragment(t *testing.T) {
 }
 
 func TestFetcherFetchHTMLError(t *testing.T) {
-	f := newFetcher(1)
+	f := newFetcher(1, false)
 
 	for _, s := range []string{":", nonExistentURL} {
 		n, err := f.fetchHTML(s, "")

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ func main() {
 		fail(err)
 	}
 
-	c, err := newChecker(args.url, args.concurrency)
+	c, err := newChecker(args.url, args.concurrency, args.ignoreFragments)
 
 	if err != nil {
 		fail(err)

--- a/setup_test.go
+++ b/setup_test.go
@@ -14,6 +14,7 @@ const nonExistentURL = "http://localhost:8080/bar"
 const erroneousURL = "http://localhost:8080/erroneous"
 const fragmentURL = "http://localhost:8080/fragment"
 const tagsURL = "http://localhost:8080/tags"
+const nonExistentIDURL = "http://localhost:8080/#non-existent-id"
 
 type handler struct{}
 


### PR DESCRIPTION
Also a few other very minor changes.

All tests pass.

`go fmt`, `go vet`, `go lint` and [`megacheck`](https://github.com/dominikh/go-tools/tree/master/cmd/megacheck) has no complaints.

Example usage:

```
% ./muffet https://arodseth.com
https://arodseth.com
        ERROR   https://stackoverflow.com/questions/166506/finding-local-ip-addresses-using-pythons-stdlib/1267524#1267524 (ID #1267524 not found)
        ERROR   https://stackoverflow.com/questions/2951028/is-it-possible-to-include-inline-assembly-in-google-go-code/6535590#6535590 (ID #6535590 not found)
        ERROR   https://unix.stackexchange.com/questions/82598/how-do-i-write-a-retry-logic-in-script-to-keep-retrying-to-run-it-upto-5-times/82610#82610 (ID #82610 not found)
```

(returns error code 1)

```
% ./muffet -i https://arodseth.com
```

(returns error code 0)