### PR TITLE
Support URL's with containing whitespace

### DIFF
--- a/fetcher.go
+++ b/fetcher.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"mime"
-	"net/url"
 	"strings"
 	"sync"
 
@@ -151,7 +150,7 @@ redirects:
 }
 
 func separateFragment(s string) (string, string, error) {
-	u, err := url.Parse(s)
+	u, err := urlParse(s)
 
 	if err != nil {
 		return "", "", err

--- a/fetcher_test.go
+++ b/fetcher_test.go
@@ -14,7 +14,7 @@ func TestNewFetcher(t *testing.T) {
 func TestFetcherFetch(t *testing.T) {
 	f := newFetcher(fetcherOptions{})
 
-	for _, s := range []string{rootURL, existentURL, fragmentURL, erroneousURL} {
+	for _, s := range []string{rootURL, existentURL, escapedWSExistentURL, fragmentURL, erroneousURL} {
 		r, err := f.Fetch(s)
 		_, ok := r.Page()
 
@@ -43,6 +43,20 @@ func TestFetcherFetchCache(t *testing.T) {
 	assert.True(t, ok)
 
 	_, err = f.Fetch(nonExistentURL)
+	assert.NotNil(t, err)
+}
+
+func TestFetcherFetchWithEscapedWS(t *testing.T) {
+	f := newFetcher(fetcherOptions{})
+
+	r, err := f.Fetch(escapedWSExistentURL)
+	_, ok := r.Page()
+
+	assert.Equal(t, 200, r.StatusCode())
+	assert.True(t, ok)
+	assert.Nil(t, err)
+
+	_, err = f.Fetch(escapedWSNonexistentURL)
 	assert.NotNil(t, err)
 }
 

--- a/page.go
+++ b/page.go
@@ -15,7 +15,7 @@ type page struct {
 }
 
 func newPage(s string, n *html.Node, sc scraper) (*page, error) {
-	u, err := url.Parse(s)
+	u, err := urlParse(s)
 
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func newPage(s string, n *html.Node, sc scraper) (*page, error) {
 	if n, ok := scrape.Find(n, func(n *html.Node) bool {
 		return n.DataAtom == atom.Base
 	}); ok {
-		u, err := url.Parse(scrape.Attr(n, "href"))
+		u, err := urlParse(scrape.Attr(n, "href"))
 
 		if err != nil {
 			return nil, err

--- a/scraper.go
+++ b/scraper.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/yhat/scrape"
 	"golang.org/x/net/html"
@@ -48,7 +49,11 @@ func (sc scraper) Scrape(n *html.Node, base *url.URL) map[string]error {
 				continue
 			}
 
-			u, err := url.Parse(s)
+			s, err := url.PathUnescape(s)
+			s = strings.Replace(s, "\t", "", -1)
+			s = strings.Replace(s, "\r", "", -1)
+			s = strings.Replace(s, "\n", "", -1)
+			u, err := urlParse(s)
 
 			if err != nil {
 				us[s] = err

--- a/setup_test.go
+++ b/setup_test.go
@@ -19,26 +19,28 @@ import (
 )
 
 const (
-	rootURL             = "http://localhost:8080"
-	existentURL         = "http://localhost:8080/foo"
-	nonExistentURL      = "http://localhost:8080/bar"
-	erroneousURL        = "http://localhost:8080/erroneous"
-	fragmentURL         = "http://localhost:8080/fragment"
-	existentIDURL       = "http://localhost:8080/fragment#foo"
-	nonExistentIDURL    = "http://localhost:8080/fragment#bar"
-	baseURL             = "http://localhost:8080/base"
-	invalidBaseURL      = "http://localhost:8080/invalid-base"
-	redirectURL         = "http://localhost:8080/redirect"
-	infiniteRedirectURL = "http://localhost:8080/infinite-redirect"
-	invalidRedirectURL  = "http://localhost:8080/invalid-redirect"
-	timeoutURL          = "http://localhost:8080/timeout"
-	basicAuthURL        = "http://localhost:8080/basic-auth"
-	robotsTxtURL        = "http://localhost:8080/robots.txt"
-	missingMetadataURL  = "http://localhost:8081"
-	invalidRobotsTxtURL = "http://localhost:8082"
-	invalidMIMETypeURL  = "http://localhost:8083"
-	selfCertificateURL  = "https://localhost:8084"
-	noResponseURL       = "http://localhost:8085"
+	rootURL                 = "http://localhost:8080"
+	existentURL             = "http://localhost:8080/foo"
+	escapedWSExistentURL    = "http://localhost:8080/%09f%0Do%0Ao"
+	nonExistentURL          = "http://localhost:8080/bar"
+	escapedWSNonexistentURL = "http://localhost:8080/%09b%0Da%0Ar"
+	erroneousURL            = "http://localhost:8080/erroneous"
+	fragmentURL             = "http://localhost:8080/fragment"
+	existentIDURL           = "http://localhost:8080/fragment#foo"
+	nonExistentIDURL        = "http://localhost:8080/fragment#bar"
+	baseURL                 = "http://localhost:8080/base"
+	invalidBaseURL          = "http://localhost:8080/invalid-base"
+	redirectURL             = "http://localhost:8080/redirect"
+	infiniteRedirectURL     = "http://localhost:8080/infinite-redirect"
+	invalidRedirectURL      = "http://localhost:8080/invalid-redirect"
+	timeoutURL              = "http://localhost:8080/timeout"
+	basicAuthURL            = "http://localhost:8080/basic-auth"
+	robotsTxtURL            = "http://localhost:8080/robots.txt"
+	missingMetadataURL      = "http://localhost:8081"
+	invalidRobotsTxtURL     = "http://localhost:8082"
+	invalidMIMETypeURL      = "http://localhost:8083"
+	selfCertificateURL      = "https://localhost:8084"
+	noResponseURL           = "http://localhost:8085"
 )
 
 type handler struct{}
@@ -48,7 +50,8 @@ func (handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch r.URL.Path {
 	case "", "/":
-		w.Write([]byte(htmlWithBody(`<a href="/foo" />`)))
+		w.Write([]byte(htmlWithBody(`<a href="/f
+oo" />`)))
 	case "/foo":
 		w.Write([]byte(htmlWithBody(`<a href="/" />`)))
 	case "/erroneous":
@@ -59,12 +62,14 @@ func (handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			<a href="#foo" />
 		`)))
 	case "/fragment":
-		w.Write([]byte(htmlWithBody(`<a id="foo" href="#foo" />`)))
+		w.Write([]byte(htmlWithBody(`<a id="foo" href="#f
+oo" />`)))
 	case "/base":
 		w.Write([]byte(`
 			<html>
 				<head>
-					<base href="/parent/" />
+					<base href="/par
+ent/" />
 				</head>
 				<body>
 					<a href="child" />

--- a/url_inspector.go
+++ b/url_inspector.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/temoto/robotstxt"
 	"github.com/yterajima/go-sitemap"
@@ -16,7 +17,7 @@ type urlInspector struct {
 }
 
 func newURLInspector(s string, r, sm bool) (urlInspector, error) {
-	u, err := url.Parse(s)
+	u, err := urlParse(s)
 
 	if err != nil {
 		return urlInspector{}, err
@@ -71,4 +72,16 @@ func (i urlInspector) Inspect(u *url.URL) bool {
 	}
 
 	return u.Hostname() == i.hostname
+}
+
+// unescape and remove any embedded tabs and CR/LF characters
+func urlParse(s string) (*url.URL, error) {
+	s, err := url.PathUnescape(s)
+	if err != nil {
+		return nil, err
+	}
+	s = strings.Replace(s, "\t", "", -1)
+	s = strings.Replace(s, "\r", "", -1)
+	s = strings.Replace(s, "\n", "", -1)
+	return url.Parse(s)
 }


### PR DESCRIPTION
Improve support for checking URL's containing whitepace by unescaping
the URL and then removing tabs and CR/LF characters.  This allows
URL's such as the one below to be checked correctly:

<a href="/path/to/page/i-am-a-really-long-
title-that-got-wrapped">Really Long Title</a>

Browsers such as Chrome and Firefox remove the embedded whitespace
resulting in the URL
'/path/to/page/i-am-a-really-long-title-that-got-wrapped'.  This
commit tries to duplicate this behavior.