### PR TITLE
Add an option to check links on a single page only

### DIFF
--- a/arguments.go
+++ b/arguments.go
@@ -14,7 +14,7 @@ import (
 var usage = fmt.Sprintf(`Muffet, the web repairgirl
 
 Usage:
-	muffet [-c <concurrency>] [-e <pattern>...] [-f] [-j <header>...] [-l <times>] [-r] [-s] [-t <seconds>] [-v] [-x] <url>
+	muffet [-c <concurrency>] [-e <pattern>...] [-f] [-j <header>...] [-l <times>] [-p] [-r] [-s] [-t <seconds>] [-v] [-x] <url>
 
 Options:
 	-c, --concurrency <concurrency>   Roughly maximum number of concurrent HTTP connections. [default: %v]
@@ -23,6 +23,7 @@ Options:
 	-h, --help                        Show this help.
 	-j, --header <header>...          Set custom headers.
 	-l, --limit-redirections <times>  Limit a number of redirections. [default: %v]
+	-p, --one-page-only               Only check links found in the given URL, do not follow links.
 	-r, --follow-robots-txt           Follow robots.txt when scraping.
 	-s, --follow-sitemap-xml          Scrape only pages listed in sitemap.xml.
 	-t, --timeout <seconds>           Set timeout for HTTP requests in seconds. [default: %v]
@@ -42,6 +43,7 @@ type arguments struct {
 	URL             string
 	Verbose,
 	SkipTLSVerification bool
+	OnePageOnly bool
 }
 
 func getArguments(ss []string) (arguments, error) {
@@ -94,6 +96,7 @@ func getArguments(ss []string) (arguments, error) {
 		args["<url>"].(string),
 		args["--verbose"].(bool),
 		args["--skip-tls-verification"].(bool),
+		args["--one-page-only"].(bool),
 	}, nil
 }
 

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -27,6 +27,8 @@ func TestGetArguments(t *testing.T) {
 		{"--verbose", "https://foo.com"},
 		{"-v", "-f", "https://foo.com"},
 		{"-v", "--ignore-fragments", "https://foo.com"},
+		{"-p", "https://foo.com"},
+		{"--one-page-only", "https://foo.com"},
 	} {
 		_, err := getArguments(ss)
 		assert.Nil(t, err)

--- a/checker.go
+++ b/checker.go
@@ -94,8 +94,11 @@ func (c checker) checkPage(p *page) {
 				ec <- formatLinkError(u, err)
 			}
 
-			if p, ok := r.Page(); ok && c.urlInspector.Inspect(p.URL()) {
-				c.addPage(p)
+			// only consider adding the page to the list if we're recursing
+			if !c.fetcher.options.OnePageOnly {
+				if p, ok := r.Page(); ok && c.urlInspector.Inspect(p.URL()) {
+					c.addPage(p)
+				}
 			}
 		}(u)
 	}

--- a/fetcher_option.go
+++ b/fetcher_option.go
@@ -12,6 +12,7 @@ type fetcherOptions struct {
 	IgnoreFragments  bool
 	MaxRedirections  int
 	Timeout          time.Duration
+	OnePageOnly      bool
 }
 
 func (o *fetcherOptions) Initialize() {

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func command(ss []string, w io.Writer) (int, error) {
 			args.IgnoreFragments,
 			args.MaxRedirections,
 			args.Timeout,
+			args.OnePageOnly,
 		},
 		args.FollowRobotsTxt,
 		args.FollowSitemapXML,


### PR DESCRIPTION
I work on a large documentation site and find Muffet is an excellent tool, but I don't need to re-check the whole site when I'm changing a single page. This pull request adds a flag `--one-page-only` that checks all the links on the page, but doesn't follow the links and check what is on those pages. For our use case it would be great to only check the part we were working on most of the time, and then run the whole check periodically.