### PR TITLE
Adding option to follow URL parameters

### DIFF
--- a/arguments.go
+++ b/arguments.go
@@ -14,7 +14,7 @@ import (
 var usage = fmt.Sprintf(`Muffet, the web repairgirl
 
 Usage:
-	muffet [-c <concurrency>] [-e <pattern>...] [-f] [-j <header>...] [-l <times>] [-p] [-r] [-s] [-t <seconds>] [-v] [-x] <url>
+	muffet [-c <concurrency>] [-e <pattern>...] [-f] [-j <header>...] [-l <times>] [-p] [-r] [-s] [-u] [-t <seconds>] [-v] [-x] <url>
 
 Options:
 	-c, --concurrency <concurrency>   Roughly maximum number of concurrent HTTP connections. [default: %v]
@@ -26,6 +26,7 @@ Options:
 	-p, --one-page-only               Only check links found in the given URL, do not follow links.
 	-r, --follow-robots-txt           Follow robots.txt when scraping.
 	-s, --follow-sitemap-xml          Scrape only pages listed in sitemap.xml.
+	-u, --follow-url-params           Will not cut off the URL parameters.
 	-t, --timeout <seconds>           Set timeout for HTTP requests in seconds. [default: %v]
 	-v, --verbose                     Show successful results too.
 	-x, --skip-tls-verification       Skip TLS certificates verification.`,
@@ -35,7 +36,8 @@ type arguments struct {
 	Concurrency      int
 	ExcludedPatterns []*regexp.Regexp
 	FollowRobotsTxt,
-	FollowSitemapXML bool
+	FollowSitemapXML,
+	FollowURLParams bool
 	Headers         map[string]string
 	IgnoreFragments bool
 	MaxRedirections int
@@ -89,6 +91,7 @@ func getArguments(ss []string) (arguments, error) {
 		rs,
 		args["--follow-robots-txt"].(bool),
 		args["--follow-sitemap-xml"].(bool),
+		args["--follow-url-params"].(bool),
 		hs,
 		args["--ignore-fragments"].(bool),
 		r,

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -19,6 +19,8 @@ func TestGetArguments(t *testing.T) {
 		{"--limit-redirections", "4", "https://foo.com"},
 		{"-s", "https://foo.com"},
 		{"--follow-sitemap-xml", "https://foo.com"},
+		{"-u", "https://foo.com"},
+		{"--follow-url-params", "https://foo.com"},
 		{"-t", "10", "https://foo.com"},
 		{"--timeout", "10", "https://foo.com"},
 		{"-x", "https://foo.com"},

--- a/checker_option.go
+++ b/checker_option.go
@@ -4,5 +4,6 @@ type checkerOptions struct {
 	fetcherOptions
 	FollowRobotsTxt,
 	FollowSitemapXML,
+	FollowURLParams,
 	SkipTLSVerification bool
 }

--- a/fetch_result_test.go
+++ b/fetch_result_test.go
@@ -11,7 +11,7 @@ func TestNewFetchResult(t *testing.T) {
 }
 
 func TestNewFetchResultWithPage(t *testing.T) {
-	p, err := newPage("", dummyHTML(t), newScraper(nil))
+	p, err := newPage("", dummyHTML(t), newScraper(nil, false))
 	assert.Nil(t, err)
 
 	newFetchResult(200, p)
@@ -27,7 +27,7 @@ func TestFetchResultPage(t *testing.T) {
 	assert.False(t, ok)
 	assert.Equal(t, (*page)(nil), p)
 
-	q, err := newPage("", dummyHTML(t), newScraper(nil))
+	q, err := newPage("", dummyHTML(t), newScraper(nil, false))
 	assert.Nil(t, err)
 
 	p, ok = newFetchResult(200, q).Page()

--- a/fetcher.go
+++ b/fetcher.go
@@ -28,7 +28,7 @@ func newFetcher(c *fasthttp.Client, o fetcherOptions) fetcher {
 		newSemaphore(o.Concurrency),
 		newCache(),
 		o,
-		newScraper(o.ExcludedPatterns),
+		newScraper(o.ExcludedPatterns, o.FollowURLParams),
 	}
 }
 

--- a/fetcher_option.go
+++ b/fetcher_option.go
@@ -10,6 +10,7 @@ type fetcherOptions struct {
 	ExcludedPatterns []*regexp.Regexp
 	Headers          map[string]string
 	IgnoreFragments  bool
+	FollowURLParams  bool
 	MaxRedirections  int
 	Timeout          time.Duration
 	OnePageOnly      bool

--- a/main.go
+++ b/main.go
@@ -30,12 +30,14 @@ func command(ss []string, w io.Writer) (int, error) {
 			args.ExcludedPatterns,
 			args.Headers,
 			args.IgnoreFragments,
+			args.FollowURLParams,
 			args.MaxRedirections,
 			args.Timeout,
 			args.OnePageOnly,
 		},
 		args.FollowRobotsTxt,
 		args.FollowSitemapXML,
+		args.FollowURLParams,
 		args.SkipTLSVerification,
 	})
 

--- a/page.go
+++ b/page.go
@@ -22,7 +22,9 @@ func newPage(s string, n *html.Node, sc scraper) (*page, error) {
 	}
 
 	u.Fragment = ""
-	u.RawQuery = ""
+	if !sc.followURLParams {
+		u.RawQuery = ""
+	}
 
 	ids := map[string]struct{}{}
 

--- a/page_test.go
+++ b/page_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 func TestNewPage(t *testing.T) {
-	_, err := newPage("https://foo.com", dummyHTML(t), newScraper(nil))
+	_, err := newPage("https://foo.com", dummyHTML(t), newScraper(nil, false))
 	assert.Nil(t, err)
 }
 
 func TestNewPageError(t *testing.T) {
-	_, err := newPage(":", dummyHTML(t), newScraper(nil))
+	_, err := newPage(":", dummyHTML(t), newScraper(nil, false))
 	assert.NotNil(t, err)
 }
 
@@ -24,7 +24,7 @@ func TestPageURL(t *testing.T) {
 	u, err := url.Parse(s)
 	assert.Nil(t, err)
 
-	p, err := newPage(s, dummyHTML(t), newScraper(nil))
+	p, err := newPage(s, dummyHTML(t), newScraper(nil, false))
 	assert.Nil(t, err)
 
 	assert.Equal(t, u, p.URL())
@@ -34,7 +34,7 @@ func TestPageURLWithBaseTag(t *testing.T) {
 	n, err := html.Parse(strings.NewReader(`<base href="_blank" />`))
 	assert.Nil(t, err)
 
-	p, err := newPage("https://foo.com", n, newScraper(nil))
+	p, err := newPage("https://foo.com", n, newScraper(nil, false))
 	assert.Nil(t, err)
 
 	assert.Equal(t, "https://foo.com", p.URL().String())
@@ -44,7 +44,7 @@ func TestPageIDs(t *testing.T) {
 	n, err := html.Parse(strings.NewReader(`<p id="foo">Hello!</p>`))
 	assert.Nil(t, err)
 
-	p, err := newPage("https://foo.com", n, newScraper(nil))
+	p, err := newPage("https://foo.com", n, newScraper(nil, false))
 	assert.Nil(t, err)
 
 	assert.Equal(t, 1, len(p.IDs()))
@@ -77,7 +77,7 @@ func TestPageLinks(t *testing.T) {
 		n, err := html.Parse(strings.NewReader(ss[0]))
 		assert.Nil(t, err)
 
-		p, err := newPage("https://foo.com", n, newScraper(nil))
+		p, err := newPage("https://foo.com", n, newScraper(nil, false))
 		assert.Nil(t, err)
 
 		assert.Equal(t, 1, len(p.Links()))
@@ -86,4 +86,28 @@ func TestPageLinks(t *testing.T) {
 
 		assert.True(t, ok)
 	}
+}
+
+func TestPageWithParams(t *testing.T) {
+	n, err := html.Parse(strings.NewReader(`<p id="foo">Hello!</p>`))
+	assert.Nil(t, err)
+
+	url := "https://foo.com/list?page=2"
+
+	p, err := newPage(url, n, newScraper(nil, true))
+	assert.Nil(t, err)
+
+	assert.Equal(t, p.url.String(), url)
+}
+
+func TestPageWithoutParams(t *testing.T) {
+	n, err := html.Parse(strings.NewReader(`<p id="foo">Hello!</p>`))
+	assert.Nil(t, err)
+
+	url := "https://foo.com/list?page=2"
+
+	p, err := newPage(url, n, newScraper(nil, false))
+	assert.Nil(t, err)
+
+	assert.Equal(t, p.url.String(), url[:strings.IndexByte(url, '?')])
 }

--- a/scraper.go
+++ b/scraper.go
@@ -30,10 +30,11 @@ var atomToAttributes = map[atom.Atom][]string{
 
 type scraper struct {
 	excludedPatterns []*regexp.Regexp
+	followURLParams  bool
 }
 
-func newScraper(rs []*regexp.Regexp) scraper {
-	return scraper{rs}
+func newScraper(rs []*regexp.Regexp, followURLParams bool) scraper {
+	return scraper{rs, followURLParams}
 }
 
 func (sc scraper) Scrape(n *html.Node, base *url.URL) map[string]error {

--- a/scraper_test.go
+++ b/scraper_test.go
@@ -38,7 +38,7 @@ func TestScrapePage(t *testing.T) {
 
 		s, e := 0, 0
 
-		for _, err := range newScraper(nil).Scrape(n, b) {
+		for _, err := range newScraper(nil, false).Scrape(n, b) {
 			if err == nil {
 				s++
 			} else {
@@ -60,7 +60,7 @@ func TestScrapePageError(t *testing.T) {
 
 	s, e := 0, 0
 
-	for _, err := range newScraper(nil).Scrape(n, b) {
+	for _, err := range newScraper(nil, false).Scrape(n, b) {
 		if err == nil {
 			s++
 		} else {
@@ -102,6 +102,6 @@ func TestScraperIsURLExcluded(t *testing.T) {
 		rs, err := compileRegexps(x.regexps)
 		assert.Nil(t, err)
 
-		assert.Equal(t, x.answer, newScraper(rs).isURLExcluded(x.url))
+		assert.Equal(t, x.answer, newScraper(rs, false).isURLExcluded(x.url))
 	}
 }


### PR DESCRIPTION
Many thanks for the Muffet tool, it gives me a quick and solid link check. However, in a RoR site I use URL parameters for pagination and I have noticed that URL parameters are truncated by default. Therefore, not all pages are checked. I've added the -u option, which then optionally causes URL parameters not to be truncated.  