### PR TITLE
fix an issue with the colored log in Windows shell.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/m3ng9i/go-utils v0.0.0-20160811013010-f9b7dc669fde // indirect
 	github.com/m3ng9i/ran v0.1.4 // indirect
 	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/mattn/go-colorable v0.1.4
 	github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b // indirect
 	github.com/mozilla/tls-observatory v0.0.0-20190404164649-a3c1b6cfecfd // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect

--- a/go.sum
+++ b/go.sum
@@ -501,6 +501,7 @@ golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582 h1:p9xBe/w/OzkeYVKm234g55gMd
 golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191119073136-fc4aabc6c914 h1:MlY3mEfbnWGmUi4rtHOtNnnnN4UJRGSyLPx+DXA5Sq4=
 golang.org/x/net v0.0.0-20191119073136-fc4aabc6c914/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -544,6 +545,7 @@ golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191119195528-f068ffe820e4 h1:FjhQftcbpdYXneEYSWZO7+6Bu+Bi1A8VPvGYWOIzIbw=
 golang.org/x/sys v0.0.0-20191119195528-f068ffe820e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/main.go
+++ b/main.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/mattn/go-colorable"
 )
 
 func main() {
-	s, err := command(os.Args[1:], os.Stdout)
+	s, err := command(os.Args[1:], colorable.NewColorableStdout())
 
 	if err != nil {
 		fprintln(os.Stderr, err)


### PR DESCRIPTION
# Issue

When running muffet with Windows PowerShell or Command prompt, the colored log portion does not display properly.

*PowerShell on Windows 10 (1909)*
![windows-powershell](https://user-images.githubusercontent.com/12206485/86530466-cfbfb800-bef3-11ea-85f3-0bac60480007.png)

*Command prompt on Windows 10 (1909)*
![windows-command_prompt](https://user-images.githubusercontent.com/12206485/86530468-d51d0280-bef3-11ea-826d-bf4a2cebb008.png)

# Solution

I fixed it by using [go-colorable](https://github.com/mattn/go-colorable) to replace `os.Stdout`. Because this library returns `os.Stdout` as `io.Writer` for non-Windows systems, I think that this fix have no effect on the operation of other OSes.

## fixed results

*PowerShell on Windows 10 (1909)*
![windows-powershell-fixed](https://user-images.githubusercontent.com/12206485/86530758-7efd8e80-bef6-11ea-8418-3378baf5f9f6.png)

*Command prompt on Windows 10 (1909)*
![windows-command_prompt-fixed](https://user-images.githubusercontent.com/12206485/86530762-84f36f80-bef6-11ea-8ca7-77c91bdf9661.png)
