### PR TITLE
Disable default User-Agent and Accept headers if explicitly set by user

### DIFF
--- a/arguments.go
+++ b/arguments.go
@@ -31,6 +31,7 @@ type arguments struct {
 	URL                   string
 	ExcludedPatterns      []*regexp.Regexp
 	Headers               map[string]string
+	HasUserAgent          bool
 }
 
 func getArguments(ss []string) (*arguments, error) {
@@ -60,6 +61,13 @@ func getArguments(ss []string) (*arguments, error) {
 	}
 
 	args.Headers = hs
+
+	for k := range args.Headers {
+		if strings.EqualFold(k, "User-Agent") {
+			args.HasUserAgent = true
+			break
+		}
+	}
 
 	return &args, nil
 }

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -18,6 +18,7 @@ func TestGetArguments(t *testing.T) {
 		{"-e", "regex1", "-e", "regex2", "https://foo.com"},
 		{"--exclude", "regex1", "--exclude", "regex2", "https://foo.com"},
 		{"--header", "MyHeader: foo", "--header", "YourHeader: bar", "https://foo.com"},
+		{"--header", "User-Agent: custom-agent", "https://foo.com"},
 		{"-r", "4", "https://foo.com"},
 		{"--max-redirections", "4", "https://foo.com"},
 		{"--follow-robots-txt", "https://foo.com"},

--- a/command.go
+++ b/command.go
@@ -48,12 +48,13 @@ func (c *command) runWithError(ss []string) (bool, error) {
 	client := newThrottledHTTPClient(
 		c.httpClientFactory.Create(
 			httpClientOptions{
-				MaxConnectionsPerHost: args.MaxConnectionsPerHost,
-				BufferSize:            args.BufferSize,
-				MaxRedirections:       args.MaxRedirections,
-				Proxy:                 args.Proxy,
-				SkipTLSVerification:   args.SkipTLSVerification,
-				Timeout:               time.Duration(args.Timeout) * time.Second,
+				MaxConnectionsPerHost:    args.MaxConnectionsPerHost,
+				BufferSize:               args.BufferSize,
+				MaxRedirections:          args.MaxRedirections,
+				Proxy:                    args.Proxy,
+				SkipTLSVerification:      args.SkipTLSVerification,
+				Timeout:                  time.Duration(args.Timeout) * time.Second,
+				NoDefaultUserAgentHeader: args.HasUserAgent,
 			},
 		),
 		args.MaxConnections,

--- a/fasthttp_http_client.go
+++ b/fasthttp_http_client.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/valyala/fasthttp"
@@ -24,11 +25,19 @@ func (c *fasthttpHTTPClient) Get(u *url.URL, headers map[string]string) (httpRes
 	req.SetRequestURI(u.String())
 	req.SetConnectionClose()
 
-	// Some HTTP servers require "Accept" headers to be set explicitly.
-	req.Header.Add("Accept", "*/*")
+	hasAccept := false
 
 	for k, v := range headers {
 		req.Header.Add(k, v)
+
+		if strings.EqualFold(k, "Accept") {
+			hasAccept = true
+		}
+	}
+
+	// Some HTTP servers require "Accept" headers to be set explicitly.
+	if !hasAccept {
+		req.Header.Add("Accept", "*/*")
 	}
 
 	i := 0

--- a/fasthttp_http_client_factory.go
+++ b/fasthttp_http_client_factory.go
@@ -31,7 +31,8 @@ func (*fasthttpHTTPClientFactory) Create(o httpClientOptions) httpClient {
 			TLSConfig: &tls.Config{
 				InsecureSkipVerify: o.SkipTLSVerification,
 			},
-			Dial: d,
+			Dial:                     d,
+			NoDefaultUserAgentHeader: o.NoDefaultUserAgentHeader,
 		},
 		o.MaxRedirections,
 		o.Timeout,

--- a/http_client_factory.go
+++ b/http_client_factory.go
@@ -6,9 +6,10 @@ type httpClientOptions struct {
 	MaxConnectionsPerHost,
 	BufferSize,
 	MaxRedirections int
-	Proxy               string
-	SkipTLSVerification bool
-	Timeout             time.Duration
+	Proxy                    string
+	SkipTLSVerification      bool
+	Timeout                  time.Duration
+	NoDefaultUserAgentHeader bool
 }
 
 type httpClientFactory interface {


### PR DESCRIPTION
There are 2 HTTP headers automatically set by muffet: User-Agent (through fasthttp) and Accept.

This PR disables adding those headers if they were provided by the user on the command line via the `--header` argument.