### PR TITLE
improve troubleshooting broken redirect URIs

### DIFF
--- a/fasthttp_http_client.go
+++ b/fasthttp_http_client.go
@@ -36,6 +36,9 @@ func (c *fasthttpHTTPClient) Get(u *url.URL, headers map[string]string) (httpRes
 	for {
 		err := c.client.DoTimeout(&req, &res, c.timeout)
 		if err != nil {
+			if i > 0 {
+				return nil, fmt.Errorf("%w (following redirect %v)", err, req.URI())
+			}
 			return nil, err
 		}
 


### PR DESCRIPTION
One of our sites had a redirect location header that was broken (it was mostly correct but someone had removed the port number after the hostname and left the trailing colon).  This resulted in very confusing muffet output trying to track it down as the URL shown wasn't the redirect URL and the Atoi error sort of looked like a software bug.

strconv.Atoi: parsing "": invalid syntax	http://www.store.com/index.php?app=ecom&ns=prodshow&ref=33204

This minor change just wraps the error with some further context to make resolving the redirect issue quicker.
