### PR TITLE
Support scraping opengraph/twitter meta tags

### DIFF
--- a/link_finder.go
+++ b/link_finder.go
@@ -25,6 +25,7 @@ var atomToAttributes = map[atom.Atom][]string{
 	atom.Script: {"src"},
 	atom.Source: {"src", "srcset"},
 	atom.Track:  {"src"},
+	atom.Meta:   {"content"},
 }
 
 var imageDescriptorPattern = regexp.MustCompile(" [^ ]*$")
@@ -80,6 +81,12 @@ func (linkFinder) parseLinks(n *html.Node, a string) []string {
 	if a == "srcset" {
 		for _, s := range strings.Split(s, ",") {
 			ss = append(ss, imageDescriptorPattern.ReplaceAllString(strings.TrimSpace(s), ""))
+		}
+	} else if a == "content" {
+		prop := scrape.Attr(n, "property")
+		switch prop {
+		case "og:image", "og:audio", "og:video", "og:image:url", "og:image:secure_url", "twitter:image":
+			ss = append(ss, s)
 		}
 	} else {
 		ss = append(ss, s)

--- a/link_finder_test.go
+++ b/link_finder_test.go
@@ -253,6 +253,40 @@ func TestLinkFinderFindMultipleLinksInSrcSetWithDescriptors(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestLinkFinderFindMetaTags(t *testing.T) {
+	b, err := url.Parse("http://foo.com")
+	assert.Nil(t, err)
+
+	n, err := html.Parse(strings.NewReader(
+		htmlWithHead(`<meta property="og:image" content="foo.png" />`)),
+	)
+	assert.Nil(t, err)
+
+	ls := newLinkFinder(nil, nil).Find(n, b)
+
+	err, ok := ls["http://foo.com/foo.png"]
+	assert.True(t, ok)
+	assert.Nil(t, err)
+}
+
+func TestLinkFinderIgnoreMetaTags(t *testing.T) {
+	b, err := url.Parse("http://foo.com")
+	assert.Nil(t, err)
+
+	n, err := html.Parse(strings.NewReader(
+		htmlWithHead(`<meta property="og:title" content="title" />`)),
+	)
+	assert.Nil(t, err)
+
+	ls := newLinkFinder(nil, nil).Find(n, b)
+
+	assert.Len(t, ls, 0)
+}
+
 func htmlWithBody(b string) string {
 	return fmt.Sprintf(`<html><body>%v</body></html>`, b)
+}
+
+func htmlWithHead(b string) string {
+	return fmt.Sprintf(`<html><head>%v</head><body><p>hi</p></body></html>`, b)
 }


### PR DESCRIPTION
`<meta>` tags with specific `og:` and `twitter:` properties that map to URLs are now fetched.

Specific properties that are supported are:

- `og:image`
- `og:audio`
- `og:video`
- `og:image:url`
- `og:image:secure_url`
- `twitter:image`

Fixes #268 