### PR TITLE
Handle cookies

### DIFF
--- a/arguments.go
+++ b/arguments.go
@@ -122,9 +122,8 @@ func parseHeaders(headers []string) (http.Header, error) {
 		}
 
 		k := s[:i]
-		v := strings.TrimSpace(s[i+1:])
 
-		m[k] = append(m[k], v)
+		m[k] = append(m[k], strings.TrimSpace(s[i+1:]))
 	}
 
 	return m, nil

--- a/arguments.go
+++ b/arguments.go
@@ -121,9 +121,7 @@ func parseHeaders(headers []string) (http.Header, error) {
 			return nil, errors.New("invalid header format")
 		}
 
-		k := s[:i]
-
-		m[k] = append(m[k], strings.TrimSpace(s[i+1:]))
+		m.Add(s[:i], strings.TrimSpace(s[i+1:]))
 	}
 
 	return m, nil

--- a/arguments.go
+++ b/arguments.go
@@ -112,7 +112,7 @@ func compileRegexps(regexps []string) ([]*regexp.Regexp, error) {
 }
 
 func parseHeaders(headers []string) (http.Header, error) {
-	m := make(http.Header, len(headers))
+	h := make(http.Header, len(headers))
 
 	for _, s := range headers {
 		i := strings.IndexRune(s, ':')
@@ -121,10 +121,10 @@ func parseHeaders(headers []string) (http.Header, error) {
 			return nil, errors.New("invalid header format")
 		}
 
-		m.Add(s[:i], strings.TrimSpace(s[i+1:]))
+		h.Add(s[:i], strings.TrimSpace(s[i+1:]))
 	}
 
-	return m, nil
+	return h, nil
 }
 
 func reconcileDeprecatedArguments(args *arguments) {

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -80,11 +80,20 @@ func TestParseHeader(t *testing.T) {
 		},
 		{
 			[]string{"MyHeader: foo"},
-			http.Header{"MyHeader": []string{"foo"}},
+			(func() http.Header {
+				h := http.Header{}
+				h.Add("MyHeader", "foo")
+				return h
+			})(),
 		},
 		{
 			[]string{"MyHeader: foo", "YourHeader: bar"},
-			http.Header{"MyHeader": []string{"foo"}, "YourHeader": []string{"bar"}},
+			(func() http.Header {
+				h := http.Header{}
+				h.Add("MyHeader", "foo")
+				h.Add("YourHeader", "bar")
+				return h
+			})(),
 		},
 	} {
 		hs, err := parseHeaders(c.arguments)

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
@@ -68,28 +69,28 @@ func TestHelp(t *testing.T) {
 	cupaloy.SnapshotT(t, help())
 }
 
-func TestParseHeaders(t *testing.T) {
+func TestParseHeader(t *testing.T) {
 	for _, c := range []struct {
 		arguments []string
-		answer    map[string]string
+		header    http.Header
 	}{
 		{
 			nil,
-			map[string]string{},
+			http.Header{},
 		},
 		{
 			[]string{"MyHeader: foo"},
-			map[string]string{"MyHeader": "foo"},
+			http.Header{"MyHeader": []string{"foo"}},
 		},
 		{
 			[]string{"MyHeader: foo", "YourHeader: bar"},
-			map[string]string{"MyHeader": "foo", "YourHeader": "bar"},
+			http.Header{"MyHeader": []string{"foo"}, "YourHeader": []string{"bar"}},
 		},
 	} {
 		hs, err := parseHeaders(c.arguments)
 
 		assert.Nil(t, err)
-		assert.Equal(t, c.answer, hs)
+		assert.Equal(t, c.header, hs)
 	}
 }
 

--- a/command.go
+++ b/command.go
@@ -54,7 +54,7 @@ func (c *command) runWithError(ss []string) (bool, error) {
 					Proxy:                 args.Proxy,
 					SkipTLSVerification:   args.SkipTLSVerification,
 					Timeout:               time.Duration(args.Timeout) * time.Second,
-					Headers:               args.Headers,
+					Header:                args.Header,
 				},
 			),
 			args.RateLimit,

--- a/fake_http_client_test.go
+++ b/fake_http_client_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"net/url"
 )
 
@@ -12,6 +13,6 @@ func newFakeHttpClient(h func(*url.URL) (*fakeHttpResponse, error)) *fakeHttpCli
 	return &fakeHttpClient{h}
 }
 
-func (c *fakeHttpClient) Get(u *url.URL) (httpResponse, error) {
+func (c *fakeHttpClient) Get(u *url.URL, _ http.Header) (httpResponse, error) {
 	return c.handler(u)
 }

--- a/fasthttp_http_client.go
+++ b/fasthttp_http_client.go
@@ -19,7 +19,7 @@ func newFasthttpHttpClient(c *fasthttp.Client, timeout time.Duration, header htt
 	return &fasthttpHttpClient{c, timeout, header}
 }
 
-func (c *fasthttpHttpClient) Get(u *url.URL, headers http.Header) (httpResponse, error) {
+func (c *fasthttpHttpClient) Get(u *url.URL, header http.Header) (httpResponse, error) {
 	req, res := fasthttp.Request{}, fasthttp.Response{}
 	req.SetRequestURI(u.String())
 	req.SetConnectionClose()
@@ -30,7 +30,7 @@ func (c *fasthttpHttpClient) Get(u *url.URL, headers http.Header) (httpResponse,
 		}
 	}
 
-	for k, vs := range headers {
+	for k, vs := range header {
 		for _, v := range vs {
 			req.Header.Add(k, v)
 		}

--- a/fasthttp_http_client.go
+++ b/fasthttp_http_client.go
@@ -36,7 +36,7 @@ func (c *fasthttpHttpClient) Get(u *url.URL, header http.Header) (httpResponse, 
 		}
 	}
 
-	// S me HTTP servers require "Accept" headers set explicitly.
+	// Some HTTP servers require "Accept" headers set explicitly.
 	if !includeHeader(c.header, "Accept") {
 		req.Header.Add("Accept", "*/*")
 	}

--- a/fasthttp_http_client.go
+++ b/fasthttp_http_client.go
@@ -18,7 +18,7 @@ func newFasthttpHttpClient(c *fasthttp.Client, timeout time.Duration, headers ma
 	return &fasthttpHttpClient{c, timeout, headers}
 }
 
-func (c *fasthttpHttpClient) Get(u *url.URL) (httpResponse, error) {
+func (c *fasthttpHttpClient) Get(u *url.URL, headers map[string]string) (httpResponse, error) {
 	req, res := fasthttp.Request{}, fasthttp.Response{}
 	req.SetRequestURI(u.String())
 	req.SetConnectionClose()

--- a/fasthttp_http_client_factory.go
+++ b/fasthttp_http_client_factory.go
@@ -37,6 +37,6 @@ func (*fasthttpHttpClientFactory) Create(o httpClientOptions) httpClient {
 			MaxResponseBodySize:      o.MaxResponseBodySize,
 		},
 		o.Timeout,
-		o.Headers,
+		o.Header,
 	)
 }

--- a/http_client.go
+++ b/http_client.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"net/http"
 	"net/url"
 )
 
 type httpClient interface {
 	// Get sends an HTTP request with a GET method.
 	// It depends on implementation of each client what is considered as errors.
-	Get(url *url.URL, headers map[string]string) (httpResponse, error)
+	Get(url *url.URL, headers http.Header) (httpResponse, error)
 }

--- a/http_client.go
+++ b/http_client.go
@@ -7,5 +7,5 @@ import (
 type httpClient interface {
 	// Get sends an HTTP request with a GET method.
 	// It depends on implementation of each client what is considered as errors.
-	Get(url *url.URL) (httpResponse, error)
+	Get(url *url.URL, headers map[string]string) (httpResponse, error)
 }

--- a/http_client.go
+++ b/http_client.go
@@ -8,5 +8,5 @@ import (
 type httpClient interface {
 	// Get sends an HTTP request with a GET method.
 	// It depends on implementation of each client what is considered as errors.
-	Get(url *url.URL, headers http.Header) (httpResponse, error)
+	Get(url *url.URL, header http.Header) (httpResponse, error)
 }

--- a/http_client_factory.go
+++ b/http_client_factory.go
@@ -1,6 +1,9 @@
 package main
 
-import "time"
+import (
+	"net/http"
+	"time"
+)
 
 type httpClientOptions struct {
 	MaxConnectionsPerHost,
@@ -9,7 +12,7 @@ type httpClientOptions struct {
 	Proxy               string
 	SkipTLSVerification bool
 	Timeout             time.Duration
-	Headers             map[string]string
+	Header              http.Header
 }
 
 type httpClientFactory interface {

--- a/link_fetcher.go
+++ b/link_fetcher.go
@@ -73,7 +73,7 @@ func (f *linkFetcher) sendRequest(s string) (int, *page, error) {
 		return 0, nil, err
 	}
 
-	r, err := f.client.Get(u)
+	r, err := f.client.Get(u, nil)
 
 	if err != nil {
 		return 0, nil, err

--- a/redirect_http_client.go
+++ b/redirect_http_client.go
@@ -31,6 +31,10 @@ func (c *redirectHttpClient) Get(u *url.URL, header http.Header) (httpResponse, 
 	i := 0
 
 	for {
+		for _, c := range cj.Cookies(u) {
+			header.Add("cookie", c.String())
+		}
+
 		r, err := c.client.Get(u, header)
 		if err != nil {
 			return nil, c.formatError(err, i, u)

--- a/redirect_http_client.go
+++ b/redirect_http_client.go
@@ -17,9 +17,9 @@ func newRedirectHttpClient(c httpClient, maxRedirections int) httpClient {
 	return &redirectHttpClient{c, maxRedirections}
 }
 
-func (c *redirectHttpClient) Get(u *url.URL, headers map[string]string) (httpResponse, error) {
-	if headers == nil {
-		headers = map[string]string{}
+func (c *redirectHttpClient) Get(u *url.URL, header http.Header) (httpResponse, error) {
+	if header == nil {
+		header = http.Header{}
 	}
 
 	cj, err := cookiejar.New(nil)
@@ -31,7 +31,7 @@ func (c *redirectHttpClient) Get(u *url.URL, headers map[string]string) (httpRes
 	i := 0
 
 	for {
-		r, err := c.client.Get(u, headers)
+		r, err := c.client.Get(u, header)
 		if err != nil {
 			return nil, c.formatError(err, i, u)
 		}

--- a/redirect_http_client.go
+++ b/redirect_http_client.go
@@ -65,8 +65,9 @@ func (c *redirectHttpClient) Get(u *url.URL, header http.Header) (httpResponse, 
 			c := r.Header("set-cookie")
 
 			if c != "" {
-				req := http.Request{Header: http.Header{"cookie": []string{c}}}
-				cj.SetCookies(u, req.Cookies())
+				h := http.Header{}
+				h.Add("cookie", c)
+				cj.SetCookies(u, (&http.Request{Header: h}).Cookies())
 			}
 		default:
 			return nil, c.formatError(fmt.Errorf("%v", r.StatusCode()), i, u)

--- a/redirect_http_client.go
+++ b/redirect_http_client.go
@@ -65,7 +65,7 @@ func (c *redirectHttpClient) Get(u *url.URL, header http.Header) (httpResponse, 
 			c := r.Header("set-cookie")
 
 			if c != "" {
-				req := http.Request{Header: http.Header{"Cookie": []string{c}}}
+				req := http.Request{Header: http.Header{"cookie": []string{c}}}
 				cj.SetCookies(u, req.Cookies())
 			}
 		default:

--- a/redirect_http_client.go
+++ b/redirect_http_client.go
@@ -62,9 +62,7 @@ func (c *redirectHttpClient) Get(u *url.URL, header http.Header) (httpResponse, 
 				return nil, err
 			}
 
-			h := http.Header{}
-			h.Add("cookie", r.Header("set-cookie"))
-			cj.SetCookies(u, (&http.Request{Header: h}).Cookies())
+			cj.SetCookies(u, parseCookies(r.Header("set-cookie")))
 		default:
 			return nil, c.formatError(fmt.Errorf("%v", r.StatusCode()), i, u)
 		}
@@ -77,4 +75,10 @@ func (*redirectHttpClient) formatError(err error, redirections int, u *url.URL) 
 	}
 
 	return fmt.Errorf("%w (following redirect %v)", err, u.String())
+}
+
+func parseCookies(s string) []*http.Cookie {
+	h := http.Header{}
+	h.Add("cookie", s)
+	return (&http.Request{Header: h}).Cookies()
 }

--- a/redirect_http_client.go
+++ b/redirect_http_client.go
@@ -62,13 +62,9 @@ func (c *redirectHttpClient) Get(u *url.URL, header http.Header) (httpResponse, 
 				return nil, err
 			}
 
-			c := r.Header("set-cookie")
-
-			if c != "" {
-				h := http.Header{}
-				h.Add("cookie", c)
-				cj.SetCookies(u, (&http.Request{Header: h}).Cookies())
-			}
+			h := http.Header{}
+			h.Add("cookie", r.Header("set-cookie"))
+			cj.SetCookies(u, (&http.Request{Header: h}).Cookies())
 		default:
 			return nil, c.formatError(fmt.Errorf("%v", r.StatusCode()), i, u)
 		}

--- a/redirect_http_client.go
+++ b/redirect_http_client.go
@@ -15,11 +15,11 @@ func newRedirectHttpClient(c httpClient, maxRedirections int) httpClient {
 	return &redirectHttpClient{c, maxRedirections}
 }
 
-func (c *redirectHttpClient) Get(u *url.URL) (httpResponse, error) {
+func (c *redirectHttpClient) Get(u *url.URL, headers map[string]string) (httpResponse, error) {
 	i := 0
 
 	for {
-		r, err := c.client.Get(u)
+		r, err := c.client.Get(u, headers)
 		if err != nil {
 			return nil, c.formatError(err, i, u)
 		}

--- a/redirect_http_client_test.go
+++ b/redirect_http_client_test.go
@@ -30,7 +30,7 @@ func TestRedirectHttpClientGet(t *testing.T) {
 			},
 		),
 		42,
-	).Get(u)
+	).Get(u, nil)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 200, r.StatusCode())
@@ -62,7 +62,7 @@ func TestRedirectHttpClientGetWithRedirect(t *testing.T) {
 			},
 		),
 		42,
-	).Get(u)
+	).Get(u, nil)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 200, r.StatusCode())
@@ -96,7 +96,7 @@ func TestRedirectHttpClientGetWithRedirects(t *testing.T) {
 			},
 		),
 		maxRedirections,
-	).Get(u)
+	).Get(u, nil)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 200, r.StatusCode())
@@ -134,7 +134,7 @@ func TestRedirectHttpClientGetWithRelativeRedirect(t *testing.T) {
 			},
 		),
 		maxRedirections,
-	).Get(u)
+	).Get(u, nil)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 200, r.StatusCode())
@@ -163,7 +163,7 @@ func TestRedirectHttpClientFailWithTooManyRedirects(t *testing.T) {
 			},
 		),
 		maxRedirections,
-	).Get(u)
+	).Get(u, nil)
 
 	assert.Nil(t, r)
 	assert.Equal(t, err.Error(), "too many redirections")
@@ -182,7 +182,7 @@ func TestRedirectHttpClientFailWithUnsetLocationHeader(t *testing.T) {
 			},
 		),
 		42,
-	).Get(u)
+	).Get(u, nil)
 
 	assert.Nil(t, r)
 	assert.Equal(t, err.Error(), "location header not set")
@@ -205,7 +205,7 @@ func TestRedirectHttpClientFailWithInvalidLocationURL(t *testing.T) {
 			},
 		),
 		42,
-	).Get(u)
+	).Get(u, nil)
 
 	assert.Nil(t, r)
 	assert.Contains(t, err.Error(), "parse")
@@ -223,7 +223,7 @@ func TestRedirectHttpClientFailWithInvalidStatusCode(t *testing.T) {
 			},
 		),
 		42,
-	).Get(u)
+	).Get(u, nil)
 
 	assert.Nil(t, r)
 	assert.Equal(t, err.Error(), "404")
@@ -253,7 +253,7 @@ func TestRedirectHttpClientFailAfterRedirect(t *testing.T) {
 			},
 		),
 		42,
-	).Get(u)
+	).Get(u, nil)
 
 	assert.Nil(t, r)
 	assert.Contains(t, err.Error(), "following redirect http://foo.com/foo")

--- a/robots_txt_fetcher.go
+++ b/robots_txt_fetcher.go
@@ -19,7 +19,7 @@ func (f *robotsTxtFetcher) Fetch(uu *url.URL) (*robotstxt.RobotsData, error) {
 	u := *uu
 	u.Path = "robots.txt"
 
-	r, err := f.client.Get(&u)
+	r, err := f.client.Get(&u, nil)
 	if err != nil {
 		return nil, f.formatError(err)
 	}

--- a/sitemap_fetcher.go
+++ b/sitemap_fetcher.go
@@ -20,7 +20,7 @@ func (f *sitemapFetcher) Fetch(uu *url.URL) (map[string]struct{}, error) {
 	u := *uu
 	u.Path = "sitemap.xml"
 
-	r, err := f.client.Get(&u)
+	r, err := f.client.Get(&u, nil)
 	if err != nil {
 		return nil, f.formatGetError(err)
 	}

--- a/throttled_http_client.go
+++ b/throttled_http_client.go
@@ -18,7 +18,7 @@ func newThrottledHttpClient(c httpClient, requestPerSecond int, maxConnections, 
 	}
 }
 
-func (c *throttledHttpClient) Get(u *url.URL) (httpResponse, error) {
+func (c *throttledHttpClient) Get(u *url.URL, headers map[string]string) (httpResponse, error) {
 	c.connections.Request()
 	defer c.connections.Release()
 
@@ -26,5 +26,5 @@ func (c *throttledHttpClient) Get(u *url.URL) (httpResponse, error) {
 	t.Request()
 	defer t.Release()
 
-	return c.client.Get(u)
+	return c.client.Get(u, headers)
 }

--- a/throttled_http_client.go
+++ b/throttled_http_client.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"net/url"
 )
 
@@ -18,7 +19,7 @@ func newThrottledHttpClient(c httpClient, requestPerSecond int, maxConnections, 
 	}
 }
 
-func (c *throttledHttpClient) Get(u *url.URL, headers map[string]string) (httpResponse, error) {
+func (c *throttledHttpClient) Get(u *url.URL, header http.Header) (httpResponse, error) {
 	c.connections.Request()
 	defer c.connections.Release()
 
@@ -26,5 +27,5 @@ func (c *throttledHttpClient) Get(u *url.URL, headers map[string]string) (httpRe
 	t.Request()
 	defer t.Release()
 
-	return c.client.Get(u, headers)
+	return c.client.Get(u, header)
 }


### PR DESCRIPTION
Fix #308.

Note that this logic is not perfect due to the current implementation of the standard `net/http/cookiejar` package which doesn't handle folded `set-cookie` headers properly. See also https://stackoverflow.com/questions/2880047/is-it-possible-to-set-more-than-one-cookie-with-a-single-set-cookie.