### PR TITLE
Add support for ini file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ website recursively.
 - High compatibility with web browsers
 - Different tag support (`a`, `img`, `link`, `script`, etc)
 - Multiple output formats (text, JSON, and JUnit XML)
+- ini file support (configuration can be read from `muffet.ini` file)
 
 ## Installation
 

--- a/command.go
+++ b/command.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -33,7 +34,12 @@ func (c *command) Run(args []string) bool {
 }
 
 func (c *command) runWithError(ss []string) (bool, error) {
-	args, err := getArguments(ss)
+	var iniReader io.Reader = nil
+	// We try to read the ini file, if it fails, we just don't use it
+	if r, err := os.Open("muffet.ini"); err == nil {
+		iniReader = r
+	}
+	args, err := getArguments(ss, iniReader)
 	if err != nil {
 		return false, err
 	} else if args.Help {


### PR DESCRIPTION
Motivation:

In CI we have multiple invocations of muffet with mostly the same arguments.
This is cumbersome to maintain all the other args.
Thus we'd like to have support for a config file to use as default

Implementation:

Always use `muffet.ini`. I thought it was likely unecessary to support
anything different until the need comes for it.

Signed-off-by: Charly Molter <charly.molter@konghq.com>
