### PR TITLE
Make accepted HTTP response status codes configurable

### DIFF
--- a/.snapshots/TestHelp
+++ b/.snapshots/TestHelp
@@ -2,6 +2,8 @@ Usage:
   muffet.test [options] <url>
 
 Application Options:
+      --accepted-status-codes=<codes>       Accepted HTTP response status codes
+                                            (default: 200..300)
   -b, --buffer-size=<size>                  HTTP response buffer size in bytes
                                             (default: 4096)
   -c, --max-connections=<count>             Maximum number of HTTP connections
@@ -28,8 +30,6 @@ Application Options:
                                             (deprecated)
   -r, --max-redirections=<count>            Maximum number of redirections
                                             (default: 64)
-      --status-codes=<codes>                Accepted HTTP response status codes
-                                            (default: 200..299)
       --rate-limit=<rate>                   Max requests per second
   -t, --timeout=<seconds>                   Timeout for HTTP requests in
                                             seconds (default: 10)

--- a/.snapshots/TestHelp
+++ b/.snapshots/TestHelp
@@ -28,6 +28,8 @@ Application Options:
                                             (deprecated)
   -r, --max-redirections=<count>            Maximum number of redirections
                                             (default: 64)
+      --status-codes=<codes>                Accepted HTTP response status codes
+                                            (default: 200..299)
       --rate-limit=<rate>                   Max requests per second
   -t, --timeout=<seconds>                   Timeout for HTTP requests in
                                             seconds (default: 10)

--- a/arguments.go
+++ b/arguments.go
@@ -30,6 +30,7 @@ type arguments struct {
 	// TODO Remove this option.
 	JUnitOutput         bool   `long:"junit" description:"Output results as JUnit XML file (deprecated)"`
 	MaxRedirections     int    `short:"r" long:"max-redirections" value-name:"<count>" default:"64" description:"Maximum number of redirections"`
+	RawStatusCodes      string `long:"status-codes" value-name:"<codes>" default:"200..299" description:"Accepted HTTP response status codes"`
 	RateLimit           int    `long:"rate-limit" value-name:"<rate>" description:"Max requests per second"`
 	Timeout             int    `short:"t" long:"timeout" value-name:"<seconds>" default:"10" description:"Timeout for HTTP requests in seconds"`
 	Verbose             bool   `short:"v" long:"verbose" description:"Show successful results too"`
@@ -43,6 +44,7 @@ type arguments struct {
 	ExcludedPatterns    []*regexp.Regexp
 	IncludePatterns     []*regexp.Regexp
 	Header              http.Header
+	StatusCodes         statusCodeCollection
 }
 
 func getArguments(ss []string) (*arguments, error) {
@@ -72,6 +74,11 @@ func getArguments(ss []string) (*arguments, error) {
 	}
 
 	args.Header, err = parseHeaders(args.RawHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	args.StatusCodes, err = parseStatusCodeCollection(args.RawStatusCodes)
 	if err != nil {
 		return nil, err
 	}

--- a/arguments.go
+++ b/arguments.go
@@ -11,15 +11,16 @@ import (
 )
 
 type arguments struct {
-	BufferSize            int      `short:"b" long:"buffer-size" value-name:"<size>" default:"4096" description:"HTTP response buffer size in bytes"`
-	MaxConnections        int      `short:"c" long:"max-connections" value-name:"<count>" default:"512" description:"Maximum number of HTTP connections"`
-	MaxConnectionsPerHost int      `long:"max-connections-per-host" value-name:"<count>" default:"512" description:"Maximum number of HTTP connections per host"`
-	MaxResponseBodySize   int      `long:"max-response-body-size" value-name:"<size>" default:"10000000" description:"Maximum response body size to read"`
-	RawExcludedPatterns   []string `short:"e" long:"exclude" value-name:"<pattern>..." description:"Exclude URLs matched with given regular expressions"`
-	RawIncludedPatterns   []string `short:"i" long:"include" value-name:"<pattern>..." description:"Include URLs matched with given regular expressions"`
-	FollowRobotsTxt       bool     `long:"follow-robots-txt" description:"Follow robots.txt when scraping pages"`
-	FollowSitemapXML      bool     `long:"follow-sitemap-xml" description:"Scrape only pages listed in sitemap.xml (deprecated)"`
-	RawHeaders            []string `long:"header" value-name:"<header>..." description:"Custom headers"`
+	RawAcceptedStatusCodes string   `long:"accepted-status-codes" value-name:"<codes>" default:"200..300" description:"Accepted HTTP response status codes"`
+	BufferSize             int      `short:"b" long:"buffer-size" value-name:"<size>" default:"4096" description:"HTTP response buffer size in bytes"`
+	MaxConnections         int      `short:"c" long:"max-connections" value-name:"<count>" default:"512" description:"Maximum number of HTTP connections"`
+	MaxConnectionsPerHost  int      `long:"max-connections-per-host" value-name:"<count>" default:"512" description:"Maximum number of HTTP connections per host"`
+	MaxResponseBodySize    int      `long:"max-response-body-size" value-name:"<size>" default:"10000000" description:"Maximum response body size to read"`
+	RawExcludedPatterns    []string `short:"e" long:"exclude" value-name:"<pattern>..." description:"Exclude URLs matched with given regular expressions"`
+	RawIncludedPatterns    []string `short:"i" long:"include" value-name:"<pattern>..." description:"Include URLs matched with given regular expressions"`
+	FollowRobotsTxt        bool     `long:"follow-robots-txt" description:"Follow robots.txt when scraping pages"`
+	FollowSitemapXML       bool     `long:"follow-sitemap-xml" description:"Scrape only pages listed in sitemap.xml (deprecated)"`
+	RawHeaders             []string `long:"header" value-name:"<header>..." description:"Custom headers"`
 	// TODO Remove a short option.
 	IgnoreFragments bool   `short:"f" long:"ignore-fragments" description:"Ignore URL fragments"`
 	Format          string `long:"format" description:"Output format" default:"text" choice:"text" choice:"json" choice:"junit"`
@@ -30,7 +31,6 @@ type arguments struct {
 	// TODO Remove this option.
 	JUnitOutput         bool   `long:"junit" description:"Output results as JUnit XML file (deprecated)"`
 	MaxRedirections     int    `short:"r" long:"max-redirections" value-name:"<count>" default:"64" description:"Maximum number of redirections"`
-	RawStatusCodes      string `long:"status-codes" value-name:"<codes>" default:"200..299" description:"Accepted HTTP response status codes"`
 	RateLimit           int    `long:"rate-limit" value-name:"<rate>" description:"Max requests per second"`
 	Timeout             int    `short:"t" long:"timeout" value-name:"<seconds>" default:"10" description:"Timeout for HTTP requests in seconds"`
 	Verbose             bool   `short:"v" long:"verbose" description:"Show successful results too"`
@@ -41,10 +41,10 @@ type arguments struct {
 	Help                bool   `short:"h" long:"help" description:"Show this help"`
 	Version             bool   `long:"version" description:"Show version"`
 	URL                 string
+	AcceptedStatusCodes statusCodeCollection
 	ExcludedPatterns    []*regexp.Regexp
 	IncludePatterns     []*regexp.Regexp
 	Header              http.Header
-	StatusCodes         statusCodeCollection
 }
 
 func getArguments(ss []string) (*arguments, error) {
@@ -78,7 +78,7 @@ func getArguments(ss []string) (*arguments, error) {
 		return nil, err
 	}
 
-	args.StatusCodes, err = parseStatusCodeCollection(args.RawStatusCodes)
+	args.AcceptedStatusCodes, err = parseStatusCodeCollection(args.RawAcceptedStatusCodes)
 	if err != nil {
 		return nil, err
 	}

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -23,6 +23,7 @@ func TestGetArguments(t *testing.T) {
 		{"--header", "User-Agent: custom-agent", "https://foo.com"},
 		{"-r", "4", "https://foo.com"},
 		{"--max-redirections", "4", "https://foo.com"},
+		{"--status-codes", "200..299,403", "https://foo.com"},
 		{"--follow-robots-txt", "https://foo.com"},
 		{"--follow-sitemap-xml", "https://foo.com"},
 		{"-t", "10", "https://foo.com"},
@@ -57,6 +58,7 @@ func TestGetArgumentsError(t *testing.T) {
 		{"--header", "MyHeader", "https://foo.com"},
 		{"-l", "foo", "https://foo.com"},
 		{"--max-redirections", "foo", "https://foo.com"},
+		{"--status-codes", "foo", "https://foo.com"},
 		{"-t", "foo", "https://foo.com"},
 		{"--timeout", "foo", "https://foo.com"},
 	} {

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -11,6 +11,7 @@ import (
 func TestGetArguments(t *testing.T) {
 	for _, ss := range [][]string{
 		{"https://foo.com"},
+		{"--accepted-status-codes", "200..300,403", "https://foo.com"},
 		{"-b", "42", "https://foo.com"},
 		{"--buffer-size", "42", "https://foo.com"},
 		{"-c", "1", "https://foo.com"},
@@ -23,7 +24,6 @@ func TestGetArguments(t *testing.T) {
 		{"--header", "User-Agent: custom-agent", "https://foo.com"},
 		{"-r", "4", "https://foo.com"},
 		{"--max-redirections", "4", "https://foo.com"},
-		{"--status-codes", "200..299,403", "https://foo.com"},
 		{"--follow-robots-txt", "https://foo.com"},
 		{"--follow-sitemap-xml", "https://foo.com"},
 		{"-t", "10", "https://foo.com"},
@@ -49,6 +49,7 @@ func TestGetArguments(t *testing.T) {
 func TestGetArgumentsError(t *testing.T) {
 	for _, ss := range [][]string{
 		{},
+		{"--accepted-status-codes", "foo", "https://foo.com"},
 		{"-b", "foo", "https://foo.com"},
 		{"--buffer-size", "foo", "https://foo.com"},
 		{"-c", "foo", "https://foo.com"},
@@ -58,7 +59,6 @@ func TestGetArgumentsError(t *testing.T) {
 		{"--header", "MyHeader", "https://foo.com"},
 		{"-l", "foo", "https://foo.com"},
 		{"--max-redirections", "foo", "https://foo.com"},
-		{"--status-codes", "foo", "https://foo.com"},
 		{"-t", "foo", "https://foo.com"},
 		{"--timeout", "foo", "https://foo.com"},
 	} {

--- a/command.go
+++ b/command.go
@@ -62,7 +62,7 @@ func (c *command) runWithError(ss []string) (bool, error) {
 			args.MaxConnectionsPerHost,
 		),
 		args.MaxRedirections,
-		args.StatusCodes,
+		args.AcceptedStatusCodes,
 	)
 
 	fl := newLinkFilterer(args.ExcludedPatterns, args.IncludePatterns)

--- a/command.go
+++ b/command.go
@@ -62,6 +62,7 @@ func (c *command) runWithError(ss []string) (bool, error) {
 			args.MaxConnectionsPerHost,
 		),
 		args.MaxRedirections,
+		args.StatusCodes,
 	)
 
 	fl := newLinkFilterer(args.ExcludedPatterns, args.IncludePatterns)

--- a/redirect_http_client_test.go
+++ b/redirect_http_client_test.go
@@ -10,7 +10,7 @@ import (
 
 const testUrl = "http://foo.com"
 
-var acceptedStatusCodes = statusCodeCollection{[]statusCodeRange{{200, 299}}}
+var acceptedStatusCodes = statusCodeCollection{[]statusCodeRange{{200, 300}}}
 
 func TestNewRedirectHttpClient(t *testing.T) {
 	newRedirectHttpClient(newFakeHttpClient(nil), 42, acceptedStatusCodes)

--- a/redirect_http_client_test.go
+++ b/redirect_http_client_test.go
@@ -10,8 +10,10 @@ import (
 
 const testUrl = "http://foo.com"
 
+var acceptedStatusCodes = statusCodeCollection{[]statusCodeRange{{200, 299}}}
+
 func TestNewRedirectHttpClient(t *testing.T) {
-	newRedirectHttpClient(newFakeHttpClient(nil), 42)
+	newRedirectHttpClient(newFakeHttpClient(nil), 42, acceptedStatusCodes)
 }
 
 func TestRedirectHttpClientGet(t *testing.T) {
@@ -30,6 +32,7 @@ func TestRedirectHttpClientGet(t *testing.T) {
 			},
 		),
 		42,
+		acceptedStatusCodes,
 	).Get(u, nil)
 
 	assert.Nil(t, err)
@@ -62,6 +65,7 @@ func TestRedirectHttpClientGetWithRedirect(t *testing.T) {
 			},
 		),
 		42,
+		acceptedStatusCodes,
 	).Get(u, nil)
 
 	assert.Nil(t, err)
@@ -96,6 +100,7 @@ func TestRedirectHttpClientGetWithRedirects(t *testing.T) {
 			},
 		),
 		maxRedirections,
+		acceptedStatusCodes,
 	).Get(u, nil)
 
 	assert.Nil(t, err)
@@ -134,6 +139,7 @@ func TestRedirectHttpClientGetWithRelativeRedirect(t *testing.T) {
 			},
 		),
 		maxRedirections,
+		acceptedStatusCodes,
 	).Get(u, nil)
 
 	assert.Nil(t, err)
@@ -163,6 +169,7 @@ func TestRedirectHttpClientFailWithTooManyRedirects(t *testing.T) {
 			},
 		),
 		maxRedirections,
+		acceptedStatusCodes,
 	).Get(u, nil)
 
 	assert.Nil(t, r)
@@ -182,6 +189,7 @@ func TestRedirectHttpClientFailWithUnsetLocationHeader(t *testing.T) {
 			},
 		),
 		42,
+		acceptedStatusCodes,
 	).Get(u, nil)
 
 	assert.Nil(t, r)
@@ -205,6 +213,7 @@ func TestRedirectHttpClientFailWithInvalidLocationURL(t *testing.T) {
 			},
 		),
 		42,
+		acceptedStatusCodes,
 	).Get(u, nil)
 
 	assert.Nil(t, r)
@@ -223,6 +232,7 @@ func TestRedirectHttpClientFailWithInvalidStatusCode(t *testing.T) {
 			},
 		),
 		42,
+		acceptedStatusCodes,
 	).Get(u, nil)
 
 	assert.Nil(t, r)
@@ -253,6 +263,7 @@ func TestRedirectHttpClientFailAfterRedirect(t *testing.T) {
 			},
 		),
 		42,
+		acceptedStatusCodes,
 	).Get(u, nil)
 
 	assert.Nil(t, r)

--- a/status_code_collection.go
+++ b/status_code_collection.go
@@ -1,0 +1,41 @@
+package main
+
+import "strings"
+
+type statusCodeCollection struct {
+	elements []statusCodeRange
+}
+
+func parseStatusCodeCollection(value string) (statusCodeCollection, error) {
+	statusCodeRanges := []statusCodeRange{}
+
+	for _, partial := range strings.Split(value, ",") {
+		if len(value) == 0 {
+			continue
+		}
+
+		statusCodeRange, err := parseStatusCodeRange(partial)
+
+		if err != nil {
+			return statusCodeCollection{}, err
+		}
+
+		statusCodeRanges = append(statusCodeRanges, *statusCodeRange)
+	}
+
+	if len(statusCodeRanges) == 0 {
+		statusCodeRanges = append(statusCodeRanges, statusCodeRange{200, 299})
+	}
+
+	return statusCodeCollection{statusCodeRanges}, nil
+}
+
+func (c *statusCodeCollection) isInCollection(code int) bool {
+	for _, element := range c.elements {
+		if element.isInRange(code) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/status_code_collection.go
+++ b/status_code_collection.go
@@ -24,7 +24,7 @@ func parseStatusCodeCollection(value string) (statusCodeCollection, error) {
 	}
 
 	if len(statusCodeRanges) == 0 {
-		statusCodeRanges = append(statusCodeRanges, statusCodeRange{200, 299})
+		statusCodeRanges = append(statusCodeRanges, statusCodeRange{200, 300})
 	}
 
 	return statusCodeCollection{statusCodeRanges}, nil

--- a/status_code_collection_test.go
+++ b/status_code_collection_test.go
@@ -20,7 +20,7 @@ func TestParsingEmptyStatusCodeCollection(t *testing.T) {
 }
 
 func TestParsingValidStatusCodeCollection(t *testing.T) {
-	collection, err := parseStatusCodeCollection("200..206,403")
+	collection, err := parseStatusCodeCollection("200..207,403")
 
 	assert.Nil(t, err)
 
@@ -41,5 +41,7 @@ func TestParsingInvalidStatusCodeCollection(t *testing.T) {
 	collection, err := parseStatusCodeCollection("200,foo")
 
 	assert.NotNil(t, err)
-	assert.Nil(t, collection)
+
+	assert.NotNil(t, collection)
+	assert.NotNil(t, collection.isInCollection(200))
 }

--- a/status_code_collection_test.go
+++ b/status_code_collection_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParsingEmptyStatusCodeCollection(t *testing.T) {
+	collection, err := parseStatusCodeCollection("")
+
+	assert.Nil(t, err)
+
+	assert.False(t, collection.isInCollection(199))
+	assert.True(t, collection.isInCollection(200))
+	assert.True(t, collection.isInCollection(201))
+
+	assert.True(t, collection.isInCollection(298))
+	assert.True(t, collection.isInCollection(299))
+	assert.False(t, collection.isInCollection(300))
+}
+
+func TestParsingValidStatusCodeCollection(t *testing.T) {
+	collection, err := parseStatusCodeCollection("200..206,403")
+
+	assert.Nil(t, err)
+
+	assert.False(t, collection.isInCollection(199))
+	assert.True(t, collection.isInCollection(200))
+	assert.True(t, collection.isInCollection(201))
+
+	assert.True(t, collection.isInCollection(205))
+	assert.True(t, collection.isInCollection(206))
+	assert.False(t, collection.isInCollection(207))
+
+	assert.False(t, collection.isInCollection(402))
+	assert.True(t, collection.isInCollection(403))
+	assert.False(t, collection.isInCollection(404))
+}
+
+func TestParsingInvalidStatusCodeCollection(t *testing.T) {
+	collection, err := parseStatusCodeCollection("200,foo")
+
+	assert.NotNil(t, err)
+	assert.Nil(t, collection)
+}

--- a/status_code_range.go
+++ b/status_code_range.go
@@ -18,7 +18,7 @@ func parseStatusCodeRange(value string) (*statusCodeRange, error) {
 	fixedMatch := fixedCodePattern.FindAllStringSubmatch(value, -1)
 	if len(fixedMatch) > 0 {
 		code, _ := strconv.Atoi(fixedMatch[0][1])
-		return &statusCodeRange{code, code}, nil
+		return &statusCodeRange{code, code + 1}, nil
 	}
 
 	rangeMatch := rangeCodePattern.FindAllStringSubmatch(value, -1)
@@ -32,5 +32,5 @@ func parseStatusCodeRange(value string) (*statusCodeRange, error) {
 }
 
 func (r *statusCodeRange) isInRange(code int) bool {
-	return r.start <= code && r.end >= code
+	return code >= r.start && code < r.end
 }

--- a/status_code_range.go
+++ b/status_code_range.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+)
+
+var fixedCodePattern = regexp.MustCompile(`^\s*(\d{3})\s*$`)
+var rangeCodePattern = regexp.MustCompile(`^\s*(\d{3})\s*\.\.\s*(\d{3})\s*$`)
+
+type statusCodeRange struct {
+	start int
+	end   int
+}
+
+func parseStatusCodeRange(value string) (*statusCodeRange, error) {
+	fixedMatch := fixedCodePattern.FindAllStringSubmatch(value, -1)
+	if len(fixedMatch) > 0 {
+		code, _ := strconv.Atoi(fixedMatch[0][1])
+		return &statusCodeRange{code, code}, nil
+	}
+
+	rangeMatch := rangeCodePattern.FindAllStringSubmatch(value, -1)
+	if len(rangeMatch) > 0 {
+		start, _ := strconv.Atoi(rangeMatch[0][1])
+		end, _ := strconv.Atoi(rangeMatch[0][2])
+		return &statusCodeRange{start, end}, nil
+	}
+
+	return nil, errors.New("invalid HTTP response status code value")
+}
+
+func (r *statusCodeRange) isInRange(code int) bool {
+	return r.start <= code && r.end >= code
+}

--- a/status_code_range_test.go
+++ b/status_code_range_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParsingFixedStatusCode(t *testing.T) {
+	code, err := parseStatusCodeRange("403")
+
+	assert.Nil(t, err)
+	assert.Equal(t, 403, code.start)
+	assert.Equal(t, 403, code.end)
+}
+
+func TestParsingStatusCodeRange(t *testing.T) {
+	code, err := parseStatusCodeRange("200..299")
+
+	assert.Nil(t, err)
+	assert.Equal(t, 200, code.start)
+	assert.Equal(t, 299, code.end)
+}
+
+func TestParsingInvalidStatusCode(t *testing.T) {
+	code, err := parseStatusCodeRange("foo")
+
+	assert.NotNil(t, err)
+	assert.Nil(t, code)
+}
+
+func TestInRangeOfStatusCode(t *testing.T) {
+	code := statusCodeRange{200, 299}
+
+	assert.False(t, code.isInRange(199))
+	assert.True(t, code.isInRange(200))
+	assert.True(t, code.isInRange(201))
+
+	assert.True(t, code.isInRange(298))
+	assert.True(t, code.isInRange(299))
+	assert.False(t, code.isInRange(300))
+}

--- a/status_code_range_test.go
+++ b/status_code_range_test.go
@@ -10,15 +10,15 @@ func TestParsingFixedStatusCode(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, 403, code.start)
-	assert.Equal(t, 403, code.end)
+	assert.Equal(t, 404, code.end)
 }
 
 func TestParsingStatusCodeRange(t *testing.T) {
-	code, err := parseStatusCodeRange("200..299")
+	code, err := parseStatusCodeRange("200..300")
 
 	assert.Nil(t, err)
 	assert.Equal(t, 200, code.start)
-	assert.Equal(t, 299, code.end)
+	assert.Equal(t, 300, code.end)
 }
 
 func TestParsingInvalidStatusCode(t *testing.T) {
@@ -29,7 +29,7 @@ func TestParsingInvalidStatusCode(t *testing.T) {
 }
 
 func TestInRangeOfStatusCode(t *testing.T) {
-	code := statusCodeRange{200, 299}
+	code := statusCodeRange{200, 300}
 
 	assert.False(t, code.isInRange(199))
 	assert.True(t, code.isInRange(200))


### PR DESCRIPTION
This pull request adds a new optional argument `--status-codes` to make the accepted HTTP response status codes configurable and solves #189 and #291.

I use muffet to check all links on https://tinylog.org/. However, some websites (e.g. https://stackoverflow.com, https://www.baeldung.com, and https://mkyong.com/) respond with status code 403 instead of 200 to muffet. Therefore, I would like to accept 403 as valid HTTP response status code.