### PR TITLE
Added `--retries` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.snap
+.idea
 .snapcraft
 coverage.txt
 dist

--- a/.snapshots/TestHelp
+++ b/.snapshots/TestHelp
@@ -23,6 +23,7 @@ Application Options:
                                             sitemap.xml (deprecated)
       --header=<header>...                  Custom headers
   -f, --ignore-fragments                    Ignore URL fragments
+      --retries=<retries>                   Retry network errors (default: 3)
       --dns-resolver=<address>              Custom DNS resolver
       --format=[text|json|junit]            Output format (default: text)
       --json                                Output results in JSON (deprecated)

--- a/arguments.go
+++ b/arguments.go
@@ -23,6 +23,7 @@ type arguments struct {
 	RawHeaders             []string `long:"header" value-name:"<header>..." description:"Custom headers"`
 	// TODO Remove a short option.
 	IgnoreFragments bool   `short:"f" long:"ignore-fragments" description:"Ignore URL fragments"`
+	Retries         int    `long:"retries" value-name:"<retries>" default:"3" description:"Retry network errors"`
 	DnsResolver     string `long:"dns-resolver" value-name:"<address>" description:"Custom DNS resolver"`
 	Format          string `long:"format" description:"Output format" default:"text" choice:"text" choice:"json" choice:"junit"`
 	// TODO Remove this option.

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -35,6 +35,7 @@ func TestGetArguments(t *testing.T) {
 		{"--verbose", "https://foo.com"},
 		{"-v", "-f", "https://foo.com"},
 		{"-v", "--ignore-fragments", "https://foo.com"},
+		{"--retries", "3", "https://foo.com"},
 		{"--one-page-only", "https://foo.com"},
 		{"--json", "https://foo.com"},
 		{"-h"},

--- a/command.go
+++ b/command.go
@@ -77,7 +77,8 @@ func (c *command) runWithError(ss []string) (bool, error) {
 			newHtmlPageParser(newLinkFinder(fl)),
 		},
 		linkFetcherOptions{
-			args.IgnoreFragments,
+			IgnoreFragments: args.IgnoreFragments,
+			Retries:         args.Retries,
 		},
 	)
 

--- a/link_fetcher_options.go
+++ b/link_fetcher_options.go
@@ -2,4 +2,5 @@ package main
 
 type linkFetcherOptions struct {
 	IgnoreFragments bool
+	Retries         int
 }

--- a/page_checker.go
+++ b/page_checker.go
@@ -1,6 +1,8 @@
 package main
 
-import "sync"
+import (
+	"sync"
+)
 
 type pageChecker struct {
 	fetcher       *linkFetcher

--- a/page_checker_test.go
+++ b/page_checker_test.go
@@ -4,21 +4,34 @@ import (
 	"errors"
 	"net/url"
 	"testing"
+	"sync/atomic"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func newTestPageChecker(c *fakeHttpClient) *pageChecker {
+	return newTestPageCheckerWithRetries(c, 0)
+}
+
+func newTestPageCheckerWithRetries(c *fakeHttpClient, retries int) *pageChecker {
 	return newPageChecker(
 		newLinkFetcher(
 			c,
 			[]pageParser{newHtmlPageParser(newTestLinkFinder())},
-			linkFetcherOptions{},
+			linkFetcherOptions{
+				Retries: retries,
+			},
 		),
 		newLinkValidator("foo.com", nil, nil),
 		false,
 	)
 }
+
+type fakeNetError struct{}
+
+func (fakeNetError) Error() string   { return "network error" }
+func (fakeNetError) Timeout() bool   { return true }
+func (fakeNetError) Temporary() bool { return true }
 
 func newTestPage(t *testing.T, fragments map[string]struct{}, links map[string]error) page {
 	u, err := url.Parse("http://foo.com")
@@ -111,4 +124,64 @@ func TestPageCheckerDoNotCheckSamePageTwice(t *testing.T) {
 	}
 
 	assert.Equal(t, 1, i)
+}
+
+func TestPageCheckerCheckPageRetry(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		errCnt           int
+		expectedRequests int
+		success          bool
+	}{
+		{name: "no errors", errCnt: 0, expectedRequests: 1, success: true},
+		{name: "2 errors", errCnt: 2, expectedRequests: 3, success: true},
+		{name: "3 errors", errCnt: 3, expectedRequests: 3, success: false},
+	} {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				var reqCnt atomic.Int32
+				c := newTestPageCheckerWithRetries(
+					newFakeHttpClient(
+						func(u *url.URL) (*fakeHttpResponse, error) {
+							if u.String() == "http://foo.com/foo" {
+								if reqCnt.Add(1) <= int32(tt.errCnt) {
+									return nil, &fakeNetError{}
+								}
+								return newFakeHtmlResponse("http://foo.com/foo", ""), nil
+							}
+							return newFakeHtmlResponse("http://foo.com/", ""), nil
+						},
+					), 3,
+				)
+
+				go c.Check(
+					newTestPage(t, nil, map[string]error{"http://foo.com/foo": nil}),
+				)
+
+				i := 0
+
+				for r := range c.Results() {
+					i++
+					if tt.success {
+						assert.True(t, r.OK())
+					} else {
+						assert.False(t, r.OK())
+						assert.Len(t, r.ErrorLinkResults, 1)
+						assert.Len(t, r.SuccessLinkResults, 0)
+						assert.Equal(t, "http://foo.com/foo", r.ErrorLinkResults[0].URL)
+					}
+				}
+
+				if tt.success {
+					// initial page + 1 crawled page
+					assert.Equal(t, 2, i)
+				} else {
+					// the crawled page failed
+					assert.Equal(t, 1, i)
+				}
+				assert.Equal(t, int32(tt.expectedRequests), reqCnt.Load())
+			},
+		)
+	}
 }


### PR DESCRIPTION
Added `--retries` option to avoid false link check failures on site timeouts. By default it's 3 retries per url. Exponential delay starts at 500ms and doubles up to the cap of 5s.